### PR TITLE
feat: 在邮件通知中显示 UTC 时区偏移量

### DIFF
--- a/imap_client.py
+++ b/imap_client.py
@@ -123,6 +123,8 @@ def _parse_email(
     try:
         dt = parsedate_to_datetime(date_str)
         date_formatted = dt.strftime("%Y-%m-%d %H:%M")  # 用于展示
+        if dt.tzinfo is not None:
+            date_formatted += dt.strftime(" %z") # 应当展示时区信息
         date_raw = dt.isoformat()  # 用于 is_recent_email() 比较
     except Exception:
         # 日期格式非标准时降级处理，截取原始字符串前 25 位


### PR DESCRIPTION
## 问题

根据 RFC 2822 / RFC 5322，邮件的 `Date` 头本身包含时区偏移量信息，例如 `Fri, 06 Jun 2026 14:30:00 +0800`。但当前代码在格式化展示时间时使用了 `dt.strftime("%Y-%m-%d %H:%M")`，直接丢弃了时区信息，仅保留 `2026-06-06 14:30`。

当用户收到来自不同时区的邮件时，均显示为不含时区的时间字符串，用户无法判断一封 `08:00` 的邮件是北京时间早上八点还是 UTC 早上八点，容易造成混淆。

## 改动

在 `_parse_email()` 中，格式化展示时间时追加 UTC 偏移量：

```
# 之前
🕐 时间: 2026-06-06 14:30

# 之后
🕐 时间: 2026-06-06 14:30 +0800
🕐 时间: 2026-06-05 22:00 -0500
```