### PR TITLE
feat: 支持按配置时区显示邮件时间

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Outlook 可以直接使用**账户登录密码**。
 | 检查间隔（分钟） | 5 | 后台轮询间隔，建议不低于 2 分钟 |
 | 启用 AI 摘要 | 关闭 | 开启后使用 LLM 对邮件生成中文摘要 |
 | 邮件正文最大截取长度 | 500 | 预览或 AI 摘要输入的正文字符数上限 |
-| 通知显示时区 | `Asia/Shanghai` | 使用 IANA 时区名称显示通知时间，例如 `Asia/Shanghai`、`America/New_York`、`Europe/London` |
+| 通知显示时区 | `Asia/Shanghai` | 前端下拉可直接选择常见时区；若选择“自定义时区”，再填写 IANA 时区名称，例如 `Asia/Singapore`、`Australia/Sydney` |
 
 ## 📬 通知效果示例
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # 📬 邮件通知插件
 
-[![Plugin Version](https://img.shields.io/badge/Latest_Version-v1.3.2-blue.svg?style=for-the-badge&color=76bad9)](https://github.com/gangcaiyoule/astrbot_plugin_mail_notify)
+[![Plugin Version](https://img.shields.io/badge/Latest_Version-v1.3.3-blue.svg?style=for-the-badge&color=76bad9)](https://github.com/gangcaiyoule/astrbot_plugin_mail_notify)
 [![AstrBot](https://img.shields.io/badge/AstrBot-Plugin-ff69b4?style=for-the-badge)](https://github.com/AstrBotDevs/AstrBot)
 [![License](https://img.shields.io/badge/License-AGPL-green.svg?style=for-the-badge)](LICENSE)
 
@@ -240,6 +240,7 @@ Outlook 可以直接使用**账户登录密码**。
 | 检查间隔（分钟） | 5 | 后台轮询间隔，建议不低于 2 分钟 |
 | 启用 AI 摘要 | 关闭 | 开启后使用 LLM 对邮件生成中文摘要 |
 | 邮件正文最大截取长度 | 500 | 预览或 AI 摘要输入的正文字符数上限 |
+| 通知显示时区 | `Asia/Shanghai` | 使用 IANA 时区名称显示通知时间，例如 `Asia/Shanghai`、`America/New_York`、`Europe/London` |
 
 ## 📬 通知效果示例
 
@@ -248,7 +249,7 @@ Outlook 可以直接使用**账户登录密码**。
 ━━━━━━━━━━━━━━━━
 📤 发件人: 张三 <zhangsan@example.com>
 📋 主题: 关于项目进度汇报
-🕐 时间: 2026-03-07 14:30
+🕐 时间: 2026-03-07 14:30（北京时间）
 📝 预览: 你好，本周项目已完成模块A的开发...
 ```
 
@@ -259,7 +260,7 @@ Outlook 可以直接使用**账户登录密码**。
 ━━━━━━━━━━━━━━━━
 📤 发件人: 张三 <zhangsan@example.com>
 📋 主题: 关于项目进度汇报
-🕐 时间: 2026-03-07 14:30
+🕐 时间: 2026-03-07 14:30（北京时间）
 📝 AI摘要: 通知项目进度：模块A已完成开发，下周将进入测试阶段。
 ```
 
@@ -288,6 +289,7 @@ Outlook 可以直接使用**账户登录密码**。
 ## 📦 版本更新日志
 ### v1.3
 - 添加黑白名单规则
+- 时区时间转化
 
 ### v1.2
 - 兼容网易邮箱

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -76,6 +76,12 @@
     "default": 5,
     "hint": "每隔多少分钟检查一次新邮件，建议不低于 2 分钟"
   },
+  "display_timezone": {
+    "description": "通知显示时区",
+    "type": "string",
+    "default": "Asia/Shanghai",
+    "hint": "使用 IANA 时区名称，例如 Asia/Shanghai、America/New_York、Europe/London；默认显示北京时间"
+  },
   "admin_uids": {
     "description": "管理员 UID 列表",
     "type": "list",

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -80,7 +80,46 @@
     "description": "通知显示时区",
     "type": "string",
     "default": "Asia/Shanghai",
-    "hint": "使用 IANA 时区名称，例如 Asia/Shanghai、America/New_York、Europe/London；默认显示北京时间"
+    "hint": "可直接选择常见时区；如果列表里没有需要的时区，请选择“自定义时区”并填写 IANA 时区名称",
+    "options": [
+      "Asia/Shanghai",
+      "Asia/Tokyo",
+      "Asia/Seoul",
+      "Asia/Hong_Kong",
+      "Asia/Taipei",
+      "UTC",
+      "Europe/London",
+      "Europe/Paris",
+      "America/New_York",
+      "America/Chicago",
+      "America/Denver",
+      "America/Los_Angeles",
+      "__custom__"
+    ],
+    "labels": [
+      "北京时间 (Asia/Shanghai)",
+      "日本时间 (Asia/Tokyo)",
+      "韩国时间 (Asia/Seoul)",
+      "香港时间 (Asia/Hong_Kong)",
+      "台北时间 (Asia/Taipei)",
+      "UTC",
+      "英国时间 (Europe/London)",
+      "中欧时间 (Europe/Paris)",
+      "美国东部时间 (America/New_York)",
+      "美国中部时间 (America/Chicago)",
+      "美国山地时间 (America/Denver)",
+      "美国西部时间 (America/Los_Angeles)",
+      "自定义时区"
+    ]
+  },
+  "display_timezone_custom": {
+    "description": "自定义时区",
+    "type": "string",
+    "default": "",
+    "hint": "填写 IANA 时区名称，例如 Asia/Singapore、Australia/Sydney、America/Phoenix",
+    "condition": {
+      "display_timezone": "__custom__"
+    }
   },
   "admin_uids": {
     "description": "管理员 UID 列表",

--- a/main.py
+++ b/main.py
@@ -8,6 +8,11 @@ from astrbot.api.star import Context, Star, register
 
 from .imap_client import imap_fetch_new, imap_query_since, is_recent_email
 from .smtp_client import smtp_send_mail
+from .timezone_labels import (
+    format_mail_display_time,
+    format_runtime_display_time,
+    get_display_timezone_name,
+)
 
 
 @register(
@@ -25,6 +30,20 @@ class MailNotifyPlugin(Star):
         # Runtime-only status used by /mail_status; not persisted.
         self._last_check_time: dict[str, str] = {}
         self._account_status: dict[str, str] = {}
+
+    def _get_display_timezone(self) -> str:
+        configured_name = self.config.get("display_timezone", "")
+        return get_display_timezone_name(configured_name)
+
+    def _format_mail_time(self, mail_info: dict) -> str:
+        return format_mail_display_time(
+            mail_info.get("date_raw", ""),
+            mail_info.get("date", "未知"),
+            self._get_display_timezone(),
+        )
+
+    def _format_runtime_time(self, date_raw: str) -> str:
+        return format_runtime_display_time(date_raw, self._get_display_timezone())
 
     async def initialize(self):
         """插件初始化后启动后台邮件检查循环"""
@@ -53,9 +72,9 @@ class MailNotifyPlugin(Star):
                             logger.error(
                                 f"邮件通知插件：{account['email']} 检查失败: {e}"
                             )
-                        self._last_check_time[account["email"]] = (
-                            datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-                        )
+                        self._last_check_time[account["email"]] = datetime.now(
+                            timezone.utc
+                        ).isoformat()
                 await asyncio.sleep(max(interval, 1) * 60)
             except asyncio.CancelledError:
                 break
@@ -219,6 +238,7 @@ class MailNotifyPlugin(Star):
         account_name = account.get("name") or account["email"]
         use_ai = self.config.get("ai_summary", False)
         body_text = mail_info["body"]
+        display_time = self._format_mail_time(mail_info)
 
         if use_ai and body_text:
             body_text = await self._try_ai_summary(mail_info, notify_umo, body_text)
@@ -231,7 +251,7 @@ class MailNotifyPlugin(Star):
         if mail_info["from_addr"] and mail_info["from_addr"] != mail_info["from_name"]:
             lines[-1] += f" <{mail_info['from_addr']}>"
         lines.append(f"📋 主题: {mail_info['subject']}")
-        lines.append(f"🕐 时间: {mail_info['date']}")
+        lines.append(f"🕐 时间: {display_time}")
         if body_text:
             label = "📝 AI摘要" if use_ai else "📝 预览"
             lines.append(f"{label}: {body_text}")
@@ -367,7 +387,7 @@ class MailNotifyPlugin(Star):
             addr = acc.get("email", "?")
             name = acc.get("name") or addr
             status = self._account_status.get(addr, "⏳ 等待首次检查")
-            last = self._last_check_time.get(addr, "尚未检查")
+            last = self._format_runtime_time(self._last_check_time.get(addr, ""))
             lines.append(f"📧 {name} ({addr})")
             lines.append(f"   状态: {status}")
             lines.append(f"   最近检查: {last}")
@@ -407,9 +427,7 @@ class MailNotifyPlugin(Star):
             except Exception as e:
                 self._account_status[email_addr] = f"❌ {str(e)[:80]}"
                 errors.append(f"{account.get('name') or email_addr}: {e}")
-            self._last_check_time[email_addr] = datetime.now().strftime(
-                "%Y-%m-%d %H:%M:%S"
-            )
+            self._last_check_time[email_addr] = datetime.now(timezone.utc).isoformat()
 
         if errors:
             yield event.plain_result("⚠️ 部分邮箱检查失败:\n" + "\n".join(errors))
@@ -476,7 +494,7 @@ class MailNotifyPlugin(Star):
         ]
         for i, m in enumerate(emails, 1):
             lines.append(f"{i}. 📋 {m['subject']}")
-            lines.append(f"   📤 {m['from_name']}  🕐 {m['date']}")
+            lines.append(f"   📤 {m['from_name']}  🕐 {self._format_mail_time(m)}")
         yield event.plain_result("\n".join(lines))
 
     @filter.command("mail_reply")

--- a/main.py
+++ b/main.py
@@ -33,6 +33,8 @@ class MailNotifyPlugin(Star):
 
     def _get_display_timezone(self) -> str:
         configured_name = self.config.get("display_timezone", "")
+        if configured_name == "__custom__":
+            configured_name = self.config.get("display_timezone_custom", "")
         return get_display_timezone_name(configured_name)
 
     def _format_mail_time(self, mail_info: dict) -> str:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 name: astrbot_plugin_mail_notify
 display_name: 📬 邮件通知
 desc: 监控邮箱新邮件并通过消息平台发送通知，支持 Gmail、杭电邮箱等任何 IMAP 邮箱
-version: v1.3.2
+version: v1.3.3
 author: gangcaiyoule
 repo: https://github.com/gangcaiyoule/astrbot_plugin_mail_notify
 astrbot_version: ">=4.10.4"

--- a/timezone_labels.py
+++ b/timezone_labels.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+DEFAULT_DISPLAY_TIMEZONE = "Asia/Shanghai"
+
+TIMEZONE_LABELS: dict[str, str] = {
+    "UTC": "UTC",
+    "Asia/Shanghai": "北京时间",
+    "Asia/Hong_Kong": "香港时间",
+    "Asia/Taipei": "台北时间",
+    "Asia/Tokyo": "日本时间",
+    "Asia/Seoul": "韩国时间",
+    "Europe/London": "英国时间",
+    "Europe/Paris": "中欧时间",
+    "America/New_York": "美国东部时间",
+    "America/Chicago": "美国中部时间",
+    "America/Denver": "美国山地时间",
+    "America/Los_Angeles": "美国西部时间",
+}
+
+
+def get_display_timezone_name(configured_name: str | None) -> str:
+    if configured_name:
+        try:
+            ZoneInfo(configured_name)
+            return configured_name
+        except ZoneInfoNotFoundError:
+            pass
+    return DEFAULT_DISPLAY_TIMEZONE
+
+
+def _get_zone(configured_name: str | None) -> ZoneInfo:
+    return ZoneInfo(get_display_timezone_name(configured_name))
+
+
+def _get_timezone_label(configured_name: str | None, display_dt: datetime) -> str:
+    zone_name = get_display_timezone_name(configured_name)
+    label = TIMEZONE_LABELS.get(zone_name)
+    if label:
+        return label
+
+    offset = display_dt.utcoffset()
+    if offset is None:
+        return zone_name
+    return f"UTC{_format_offset(offset)}"
+
+
+def _format_offset(offset: timedelta) -> str:
+    total_minutes = int(offset.total_seconds() // 60)
+    sign = "+" if total_minutes >= 0 else "-"
+    total_minutes = abs(total_minutes)
+    hours, minutes = divmod(total_minutes, 60)
+    return f"{sign}{hours:02d}:{minutes:02d}"
+
+
+def format_mail_display_time(
+    date_raw: str, fallback_text: str, configured_name: str | None
+) -> str:
+    if not date_raw:
+        return fallback_text
+
+    try:
+        mail_dt = datetime.fromisoformat(date_raw)
+    except ValueError:
+        return fallback_text
+
+    if mail_dt.tzinfo is None:
+        mail_dt = mail_dt.replace(tzinfo=timezone.utc)
+
+    target_zone = _get_zone(configured_name)
+    display_dt = mail_dt.astimezone(target_zone)
+    timezone_label = _get_timezone_label(configured_name, display_dt)
+    return f"{display_dt.strftime('%Y-%m-%d %H:%M')}（{timezone_label}）"
+
+
+def format_runtime_display_time(date_raw: str, configured_name: str | None) -> str:
+    if not date_raw:
+        return "尚未检查"
+
+    try:
+        runtime_dt = datetime.fromisoformat(date_raw)
+    except ValueError:
+        return date_raw
+
+    if runtime_dt.tzinfo is None:
+        runtime_dt = runtime_dt.replace(tzinfo=timezone.utc)
+
+    target_zone = _get_zone(configured_name)
+    display_dt = runtime_dt.astimezone(target_zone)
+    timezone_label = _get_timezone_label(configured_name, display_dt)
+    return f"{display_dt.strftime('%Y-%m-%d %H:%M:%S')}（{timezone_label}）"


### PR DESCRIPTION
## 变更背景

之前插件通知中的邮件时间直接展示邮件 `Date` 头解析后的时间，时区信息不够直观。
仅显示 `+0800` 这类偏移量可读性一般，而且不同用户希望看到的目标时区也可能不同。

这次调整把“显示时区”做成了可配置项，默认使用北京时间，并在通知文案中展示为更友好的格式。

## 变更内容

- 新增 `display_timezone` 配置项，默认值为 `Asia/Shanghai`
- 前端配置支持常见时区下拉选择
- 新增“自定义时区”输入框，可填写 IANA 时区名称
- 新邮件通知时间统一转换为用户配置的目标时区显示
- `/mail_query` 返回的邮件时间统一转换为用户配置的目标时区显示
- `/mail_status` 中最近检查时间也统一按配置时区显示
- 新增独立的时区标签映射文件，统一维护常见时区的中文名称

## 显示效果

例如邮件原始时间为美国东部时间：

```text
2026-06-24 10:30 -0400
```

当用户配置为 `Asia/Shanghai` 时，通知中会显示为：

```text
🕐 时间: 2026-06-24 22:30（北京时间）
```

当用户配置为 `America/New_York` 时，则会显示为：

```text
🕐 时间: 2026-06-24 10:30（美国东部时间）
```

## 兼容性说明

- 不影响现有邮件新旧判断逻辑，时间比较仍基于标准化原始时间
- 若用户填写了无效时区，将自动回退到默认时区 `Asia/Shanghai`
- 若所选时区没有预设中文标签，将回退显示为 `UTC+/-hh:mm`

## 验证

- 已通过 Python 语法编译检查
- 已验证示例邮件时间可以正确转换到不同目标时区
