### PR TITLE
fix: 为邮件头和正文解码增加兜底逻辑

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # 📬 邮件通知插件
 
-[![Plugin Version](https://img.shields.io/badge/Latest_Version-v1.3.3-blue.svg?style=for-the-badge&color=76bad9)](https://github.com/gangcaiyoule/astrbot_plugin_mail_notify)
+[![Plugin Version](https://img.shields.io/badge/Latest_Version-v1.3.4-blue.svg?style=for-the-badge&color=76bad9)](https://github.com/gangcaiyoule/astrbot_plugin_mail_notify)
 [![AstrBot](https://img.shields.io/badge/AstrBot-Plugin-ff69b4?style=for-the-badge)](https://github.com/AstrBotDevs/AstrBot)
 [![License](https://img.shields.io/badge/License-AGPL-green.svg?style=for-the-badge)](LICENSE)
 

--- a/mail_utils.py
+++ b/mail_utils.py
@@ -2,6 +2,23 @@ import re
 from email.header import decode_header
 
 
+def _decode_bytes(value: bytes, charset: str | None) -> str:
+    """Decode bytes with conservative fallbacks for non-standard mail charsets."""
+    normalized = (charset or "utf-8").strip().lower()
+    if normalized in {"unknown-8bit", "unknown8bit"}:
+        normalized = "latin-1"
+
+    for candidate in (normalized, "utf-8", "latin-1"):
+        try:
+            return value.decode(candidate, errors="replace")
+        except LookupError:
+            continue
+        except UnicodeDecodeError:
+            continue
+
+    return value.decode("utf-8", errors="replace")
+
+
 def decode_mime_header(value: str) -> str:
     """Decode a MIME encoded header value to plain text."""
     if not value:
@@ -10,7 +27,7 @@ def decode_mime_header(value: str) -> str:
     decoded = []
     for part, charset in parts:
         if isinstance(part, bytes):
-            decoded.append(part.decode(charset or "utf-8", errors="replace"))
+            decoded.append(_decode_bytes(part, charset))
         else:
             decoded.append(part)
     return "".join(decoded)
@@ -32,21 +49,18 @@ def extract_text_body(msg) -> str:
             if ctype == "text/plain":
                 payload = part.get_payload(decode=True)
                 if payload:
-                    charset = part.get_content_charset() or "utf-8"
-                    body = payload.decode(charset, errors="replace")
+                    body = _decode_bytes(payload, part.get_content_charset())
                     break
             elif ctype == "text/html" and not body:
                 payload = part.get_payload(decode=True)
                 if payload:
-                    charset = part.get_content_charset() or "utf-8"
-                    html = payload.decode(charset, errors="replace")
+                    html = _decode_bytes(payload, part.get_content_charset())
                     body = re.sub(r"<[^>]+>", "", html)
                     body = re.sub(r"\s+", " ", body).strip()
     else:
         payload = msg.get_payload(decode=True)
         if payload:
-            charset = msg.get_content_charset() or "utf-8"
-            text = payload.decode(charset, errors="replace")
+            text = _decode_bytes(payload, msg.get_content_charset())
             if msg.get_content_type() == "text/html":
                 text = re.sub(r"<[^>]+>", "", text)
                 text = re.sub(r"\s+", " ", text).strip()

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 name: astrbot_plugin_mail_notify
 display_name: 📬 邮件通知
 desc: 监控邮箱新邮件并通过消息平台发送通知，支持 Gmail、杭电邮箱等任何 IMAP 邮箱
-version: v1.3.3
+version: v1.3.4
 author: gangcaiyoule
 repo: https://github.com/gangcaiyoule/astrbot_plugin_mail_notify
 astrbot_version: ">=4.10.4"


### PR DESCRIPTION
## 变更内容

修复部分邮件使用非标准字符集时导致解析失败的问题，尤其是 QQ 邮箱中可能出现的 `unknown-8bit` 编码。

本次改动主要集中在邮件解码层：

- 为字节解码新增统一的安全兜底逻辑
- 对 `unknown-8bit`、`unknown8bit` 这类非标准 charset 做兼容处理
- 当原始 charset 不可用时，按保守顺序回退到可用编码，避免直接抛出异常
- `decode_mime_header()` 和 `extract_text_body()` 统一复用该兜底逻辑

## 修复效果

修复后，即使邮件头或正文中出现异常 charset，也不会因为解码失败导致 `/mail_check` 整体报错。

## 验证

已本地验证以下情况不会再直接抛异常：

- `unknown-8bit`
- 无效 charset 名称
- MIME 邮件头解码路径

Closes #13